### PR TITLE
Remove bin part from snapcraft.yaml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
-        run: tox -e lint
+        run: tox -e pep8
 
   unit-test:
     name: Unit tests
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: tox -e unit
+        run: tox -e py3
 
   build:
     name: Build snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,12 +36,6 @@ parts:
     plugin: dump
     source: bundles/
 
-  bin:
-    source: bin/
-    plugin: dump
-    organize:
-      '*': bin/
-
 plugs:
   peers:
     interface: content


### PR DESCRIPTION
The bin part was unintentionally left in the snapcraft.yaml. Remove it to allow the snap to build again.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>