### PR TITLE
Rename upgrade hook to post-refresh

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,4 +30,4 @@ console_scripts =
 snaphelpers.hooks =
     configure = sunbeam.hooks:configure
     install = sunbeam.hooks:install
-    upgrade = sunbeam.hooks:install
+    post-refresh = sunbeam.hooks:install


### PR DESCRIPTION
Upgrade is not a valid snap hook name.