### PR TITLE
Drop use of snapd-control interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,6 @@ apps:
       - network
       - network-bind
       - ssh-public-keys
-      - snapd-control
 
 parts:
   microstack:


### PR DESCRIPTION
Reserved for super priv snaps only - we'll use other mechanisms longer term to achieve the same goals.