### PR TITLE
Add configure action for all-in-one

### DIFF
--- a/configure/etc/configure/README.md
+++ b/configure/etc/configure/README.md
@@ -1,0 +1,4 @@
+# Terraform configuration for all-in-one OpenStack
+
+This directory contains a parameterized Terraform configuration
+to setup network and a user for an all-in-one OpenStack deployment.

--- a/configure/etc/configure/main.tf
+++ b/configure/etc/configure/main.tf
@@ -10,30 +10,6 @@ terraform {
 
 provider "openstack" {}
 
-variable "external_network" {
-  type = object({
-    cidr             = string
-    start            = string
-    end              = string
-    physical_network = string
-    network_type     = string
-    segmentation_id  = number
-  })
-}
-
-
-# User setup
-variable "user" {
-  type = object({
-    username = string
-    password = string
-    cidr     = string
-  })
-  sensitive = true
-}
-
-
-
 # Flavors
 resource "openstack_compute_flavor_v2" "m1_tiny" {
   name      = "m1.tiny"

--- a/configure/etc/configure/main.tf
+++ b/configure/etc/configure/main.tf
@@ -1,0 +1,181 @@
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.48.0"
+    }
+  }
+}
+
+provider "openstack" {}
+
+variable "external_network" {
+  type = object({
+    cidr             = string
+    start            = string
+    end              = string
+    physical_network = string
+    network_type     = string
+    segmentation_id  = number
+  })
+}
+
+
+# User setup
+variable "user" {
+  type = object({
+    username = string
+    password = string
+    cidr     = string
+  })
+  sensitive = true
+}
+
+
+
+# Flavors
+resource "openstack_compute_flavor_v2" "m1_tiny" {
+  name      = "m1.tiny"
+  ram       = "512"
+  vcpus     = "1"
+  disk      = "4"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_small" {
+  name      = "m1.small"
+  ram       = "2048"
+  vcpus     = "1"
+  disk      = "30"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_medium" {
+  name      = "m1.medium"
+  ram       = "4096"
+  vcpus     = "2"
+  disk      = "60"
+  is_public = true
+}
+
+resource "openstack_compute_flavor_v2" "m1_large" {
+  name      = "m1.large"
+  ram       = "8192"
+  vcpus     = "4"
+  disk      = "90"
+  is_public = true
+}
+
+resource "openstack_images_image_v2" "ubuntu_jammy" {
+  name             = "ubuntu-jammy"
+  image_source_url = "http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  container_format = "bare"
+  disk_format      = "qcow2"
+  visibility       = "public"
+}
+
+# External networking
+resource "openstack_networking_network_v2" "external_network" {
+  name           = "external-network"
+  admin_state_up = true
+  external       = true
+  segments {
+    physical_network = var.external_network.physical_network
+    network_type     = var.external_network.network_type
+    segmentation_id  = var.external_network.segmentation_id
+  }
+}
+
+resource "openstack_networking_subnet_v2" "external_subnet" {
+  name        = "external-subnet"
+  network_id  = openstack_networking_network_v2.external_network.id
+  cidr        = var.external_network.cidr
+  ip_version  = 4
+  enable_dhcp = false
+  allocation_pool {
+    start = var.external_network.start
+    end   = var.external_network.end
+  }
+}
+
+# User configuration
+resource "openstack_identity_project_v3" "users_domain" {
+  name      = "users"
+  is_domain = true
+}
+
+resource "openstack_identity_project_v3" "user_project" {
+  name      = var.user.username
+  domain_id = openstack_identity_project_v3.users_domain.id
+}
+
+resource "openstack_identity_user_v3" "user" {
+  default_project_id = openstack_identity_project_v3.user_project.id
+  name               = var.user.username
+  password           = var.user.password
+  description        = format("Cloud User - %s", var.user.username)
+  domain_id          = openstack_identity_project_v3.users_domain.id
+}
+
+# Map existing member role into configuration
+data "openstack_identity_role_v3" "member" {
+  name = "member"
+}
+
+resource "openstack_identity_role_assignment_v3" "role_assignment_1" {
+  user_id    = openstack_identity_user_v3.user.id
+  project_id = openstack_identity_project_v3.user_project.id
+  role_id    = data.openstack_identity_role_v3.member.id
+}
+
+# User networking
+resource "openstack_networking_network_v2" "user_network" {
+  name           = format("%s-network", var.user.username)
+  admin_state_up = true
+  tenant_id      = openstack_identity_project_v3.user_project.id
+}
+
+resource "openstack_networking_subnet_v2" "user_subnet" {
+  name       = format("%s-subnet", var.user.username)
+  network_id = openstack_networking_network_v2.user_network.id
+  tenant_id  = openstack_identity_project_v3.user_project.id
+  cidr       = var.user.cidr
+}
+
+resource "openstack_networking_router_v2" "user_router" {
+  name                = format("%s-router", var.user.username)
+  tenant_id           = openstack_identity_project_v3.user_project.id
+  admin_state_up      = true
+  external_network_id = openstack_networking_network_v2.external_network.id
+}
+
+resource "openstack_networking_router_interface_v2" "user_router_interface" {
+  router_id = openstack_networking_router_v2.user_router.id
+  subnet_id = openstack_networking_subnet_v2.user_subnet.id
+}
+
+# Compute quota - set unlimited as this is a sandbox deployment
+resource "openstack_compute_quotaset_v2" "compute_quota" {
+  project_id           = openstack_identity_project_v3.user_project.id
+  key_pairs            = -1
+  ram                  = -1
+  cores                = -1
+  instances            = -1
+  server_groups        = -1
+  server_group_members = -1
+}
+
+# Network quota - set unlimited as this is a sandbox deployment
+resource "openstack_networking_quota_v2" "network_quota" {
+  project_id          = openstack_identity_project_v3.user_project.id
+  floatingip          = -1
+  network             = -1
+  port                = -1
+  rbac_policy         = -1
+  router              = -1
+  security_group      = -1
+  security_group_rule = -1
+  subnet              = -1
+  subnetpool          = -1
+}

--- a/configure/etc/configure/outputs.tf
+++ b/configure/etc/configure/outputs.tf
@@ -1,0 +1,27 @@
+output "OS_USERNAME" {
+  description = "OpenStack username"
+  value       = openstack_identity_user_v3.user.name
+  sensitive   = true
+}
+
+output "OS_PASSWORD" {
+  description = "OpenStack password"
+  value       = openstack_identity_user_v3.user.password
+  sensitive   = true
+}
+
+output "OS_USER_DOMAIN_NAME" {
+  description = "OpenStack user domain name"
+  value       = openstack_identity_project_v3.users_domain.name
+}
+
+output "OS_PROJECT_DOMAIN_NAME" {
+  description = "OpenStack project domain name"
+  value       = openstack_identity_project_v3.users_domain.name
+}
+
+output "OS_PROJECT_NAME" {
+  description = "OpenStack project name"
+  value       = openstack_identity_project_v3.user_project.name
+  sensitive   = true
+}

--- a/configure/etc/configure/variables.tf
+++ b/configure/etc/configure/variables.tf
@@ -1,0 +1,22 @@
+# External networking
+variable "external_network" {
+  type = object({
+    cidr             = string
+    start            = string
+    end              = string
+    physical_network = string
+    network_type     = string
+    segmentation_id  = number
+  })
+}
+
+
+# User setup
+variable "user" {
+  type = object({
+    username = string
+    password = string
+    cidr     = string
+  })
+  sensitive = true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,7 @@ semver # BSD-3
 # Used for getting local ip address
 netifaces
 
+# Generation of user passwords
+pwgen
+
 #git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,10 @@ version: xena
 confinement: strict
 grade: devel
 
+layout:
+  /usr/share/terraform/plugins:
+    symlink: $SNAP_DATA/terraform-plugins
+
 apps:
   microstack:
     command: bin/microstack
@@ -18,6 +22,14 @@ apps:
       - network
       - network-bind
       - ssh-public-keys
+
+  terraform:
+    command: bin/terraform
+    plugs:
+      - home
+      - network
+      - ssh-public-keys
+      - juju-client-observe
 
 parts:
   microstack:
@@ -34,6 +46,32 @@ parts:
   bundles:
     plugin: dump
     source: bundles/
+
+  terraform:
+    plugin: go
+    source: https://github.com/hashicorp/terraform
+    source-depth: 1
+    source-type: git
+    source-tag: "v1.3.4"
+    build-snaps: [go]
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOFLAGS: "-mod=readonly"
+    override-build: |
+      go mod download
+      go build -ldflags "-s -w"
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp terraform $SNAPCRAFT_PART_INSTALL/bin/terraform
+    stage:
+      - bin/terraform
+
+  configure:
+    plugin: dump
+    source: configure/
+    override-build: |
+      snapcraftctl build
+      cd $SNAPCRAFT_PART_INSTALL/etc/configure
+      $SNAPCRAFT_PRIME/bin/terraform providers mirror $SNAPCRAFT_PRIME/terraform-providers
 
 plugs:
   # Needed for juju client to autodiscover microk8s cloud

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,11 +67,12 @@ parts:
 
   configure:
     plugin: dump
+    after: [terraform]
     source: configure/
     override-build: |
       snapcraftctl build
       cd $SNAPCRAFT_PART_INSTALL/etc/configure
-      $SNAPCRAFT_PRIME/bin/terraform providers mirror $SNAPCRAFT_PRIME/terraform-providers
+      $SNAPCRAFT_STAGE/bin/terraform providers mirror $SNAPCRAFT_STAGE/terraform-providers
 
 plugs:
   # Needed for juju client to autodiscover microk8s cloud

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import subprocess
+from typing import Optional
+
+import click
+import pwgen
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands import juju
+from sunbeam.jobs.common import BaseStep, Result, ResultType, Status
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+VARIABLE_DEFAULTS = {
+    "user": {
+        "username": "demo",
+        "cidr": "192.168.122.0/24",
+    },
+    "external_network": {
+        "cidr": "10.246.112.0/21",
+        "start": "10.246.115.51",
+        "end": "10.246.115.254",
+        "physical_network": "physnet1",
+        "network_type": "flat",
+        "segmentation_id": 0,
+    },
+}
+
+
+class ConfigureCloudStep(BaseStep):
+    """Default cloud configuration for all-in-one install."""
+
+    def __init__(self, jhelper: juju.JujuHelper, model: str):
+        super().__init__(
+            "Configure OpenStack cloud", "Configuring OpenStack cloud for use"
+        )
+        self.jhelper = jhelper
+        self.model = model
+        self.terraform_tfvars = (
+            snap.paths.user_common / "etc" / "configure" / "terraform.tfvars.json"
+        )
+        self.variables = VARIABLE_DEFAULTS
+        if self.terraform_tfvars.exists():
+            with open(self.terraform_tfvars, "r") as tfvars:
+                self.variables.update(json.loads(tfvars.read()))
+
+    def has_prompts(self) -> bool:
+        return True
+
+    def prompt(self, console: Optional["rich.console.Console"] = None) -> None:
+        """Prompt the user for basic cloud configuration.
+
+        Prompts the user for required information for cloud configuration.
+
+        :param console: the console to prompt on
+        :type console: rich.console.Console (Optional)
+        """
+        from rich.prompt import Prompt
+
+        # User configuration
+        self.variables["user"]["username"] = Prompt.ask(
+            "Username to use for access to OpenStack",
+            default=self.variables["user"]["username"],
+            console=console,
+        )
+        self.variables["user"]["password"] = Prompt.ask(
+            "Password to use for access to OpenStack",
+            default=self.variables["user"].get("password", pwgen.pwgen(12)),
+            console=console,
+        )
+        self.variables["user"]["cidr"] = Prompt.ask(
+            "Network range to use for project network",
+            default=self.variables["user"]["cidr"],
+            console=console,
+        )
+
+        # External Network Configuration
+        self.variables["external_network"]["cidr"] = Prompt.ask(
+            "CIDR of network to use for external networking.",
+            default=self.variables["external_network"]["cidr"],
+            console=console,
+        )
+        self.variables["external_network"]["start"] = Prompt.ask(
+            "Start of IP allocation range from external network CIDR.",
+            default=self.variables["external_network"]["start"],
+            console=console,
+        )
+        self.variables["external_network"]["end"] = Prompt.ask(
+            "End of IP allocation range from external network CIDR.",
+            default=self.variables["external_network"]["end"],
+            console=console,
+        )
+        self.variables["external_network"]["physical_network"] = Prompt.ask(
+            "Neutron label for physical network to map to external network.",
+            default=self.variables["external_network"]["physical_network"],
+            console=console,
+        )
+        self.variables["external_network"]["network_type"] = Prompt.ask(
+            "Network type for access to external network.",
+            default=self.variables["external_network"]["network_type"],
+            console=console,
+            choices=['flat', 'vlan'],
+        )
+        if self.variables["external_network"]["network_type"] == "vlan":
+            self.variables["external_network"]["segmentation_id"] = Prompt.ask(
+                "VLAN ID to use for external network.",
+                default=self.variables["external_network"]["segmentation_id"],
+                console=console,
+            )
+        else:
+            self.variables["external_network"]["segmentation_id"] = 0
+
+        with open(self.terraform_tfvars, "w") as tfvars:
+            tfvars.write(json.dumps(self.variables))
+
+    def _retrieve_admin_credentials(self) -> dict:
+        """Retrieve cloud admin credentials.
+
+        Retrieve cloud admin credentials from keystone and
+        return as a dict suitable for use with subprocess
+        commands.  Variables are prefixed with OS_.
+        """
+        app = "keystone"
+        action_cmd = "get-admin-account"
+        action_result = asyncio.get_event_loop().run_until_complete(
+            self.jhelper.run_action(self.model, app, action_cmd)
+        )
+
+        if action_result.get("return-code", 0) > 1:
+            _message = "Unable to retrieve openrc from Keystone service"
+            raise click.ClickException(_message)
+
+        return {
+            "OS_USERNAME": action_result.get("username"),
+            "OS_PASSWORD": action_result.get("password"),
+            "OS_AUTH_URL": action_result.get("public-endpoint"),
+            "OS_USER_DOMAIN_NAME": action_result.get("user-domain-name"),
+            "OS_PROJECT_DOMAIN_NAME": action_result.get("project-domain-name"),
+            "OS_PROJECT_NAME": action_result.get("project-name"),
+            "OS_AUTH_VERSION": action_result.get("api-version"),
+            "OS_IDENTITY_API_VERSION": action_result.get("api-version"),
+        }
+
+    def run(self, status: Optional[Status]) -> Result:
+        """Execute configuration using terraform."""
+        os_env = self._retrieve_admin_credentials()
+        env = os.environ.copy()
+        env.update(os_env)
+        try:
+            # NOTE:
+            # terraform init will install plugins from $SNAP/terraform-plugins
+            # which is linked to from /usr/local/share/terraform/plugins
+            terraform = str(snap.paths.snap / "bin" / "terraform")
+            cmd = [terraform, "init"]
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=snap.paths.user_common / "etc" / "configure",
+                env=env,
+            )
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
+            cmd = [
+                terraform,
+                "apply",
+                "-auto-approve",
+            ]
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=snap.paths.user_common / "etc" / "configure",
+                env=env,
+            )
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
+            return Result(ResultType.COMPLETED)
+        except subprocess.CalledProcessError as e:
+            LOG.exception("Error configuring cloud")
+            return Result(ResultType.FAILED, str(e))
+
+
+@click.command()
+def configure() -> None:
+    """Configure cloud with some sane defaults."""
+    # NOTE: install to user writable location
+    src = snap.paths.snap / "etc" / "configure"
+    dst = snap.paths.user_common / "etc" / "configure"
+    LOG.debug(f"Updating {dst} from {src}...")
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+
+    model = snap.config.get("control-plane.model")
+    jhelper = juju.JujuHelper()
+
+    plan = [ConfigureCloudStep(jhelper=jhelper, model=model)]
+    for step in plan:
+        LOG.debug(f"Starting step {step.name}")
+        message = f"{step.description} ... "
+        with console.status(message) as status:
+            if step.has_prompts():
+                status.stop()
+                step.prompt(console)
+                status.start()
+
+            LOG.debug(f"Running step {step.name}")
+            result = step.run(status)
+            LOG.debug(
+                f"Finished running step {step.name}. Result: {result.result_type}"
+            )
+
+        if result.result_type == ResultType.FAILED:
+            console.print(f"{message}[red]failed[/red]")
+            raise click.ClickException(result.message)
+
+        console.print(f"{message}[green]done[/green]")
+
+    asyncio.get_event_loop().run_until_complete(jhelper.disconnect_controller())
+
+    # TODO(jamespage)
+    # Print out details for access to cloud

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -24,6 +24,7 @@ from typing import Optional
 import click
 import pwgen
 from rich.console import Console
+from rich.prompt import Prompt
 from snaphelpers import Snap
 
 from sunbeam.commands import juju
@@ -40,9 +41,9 @@ VARIABLE_DEFAULTS = {
         "cidr": "192.168.122.0/24",
     },
     "external_network": {
-        "cidr": "10.246.112.0/21",
-        "start": "10.246.115.51",
-        "end": "10.246.115.254",
+        "cidr": "10.20.20.0/24",
+        "start": "10.20.20.10",
+        "end": "10.20.20.200",
         "physical_network": "physnet1",
         "network_type": "flat",
         "segmentation_id": 0,
@@ -78,8 +79,6 @@ class ConfigureCloudStep(BaseStep):
         :param console: the console to prompt on
         :type console: rich.console.Console (Optional)
         """
-        from rich.prompt import Prompt
-
         # User configuration
         self.variables["user"]["username"] = Prompt.ask(
             "Username to use for access to OpenStack",
@@ -99,34 +98,34 @@ class ConfigureCloudStep(BaseStep):
 
         # External Network Configuration
         self.variables["external_network"]["cidr"] = Prompt.ask(
-            "CIDR of network to use for external networking.",
+            "CIDR of network to use for external networking",
             default=self.variables["external_network"]["cidr"],
             console=console,
         )
         self.variables["external_network"]["start"] = Prompt.ask(
-            "Start of IP allocation range from external network CIDR.",
+            "Start of IP allocation range for external network",
             default=self.variables["external_network"]["start"],
             console=console,
         )
         self.variables["external_network"]["end"] = Prompt.ask(
-            "End of IP allocation range from external network CIDR.",
+            "End of IP allocation range for external network",
             default=self.variables["external_network"]["end"],
             console=console,
         )
         self.variables["external_network"]["physical_network"] = Prompt.ask(
-            "Neutron label for physical network to map to external network.",
+            "Neutron label for physical network to map to external network",
             default=self.variables["external_network"]["physical_network"],
             console=console,
         )
         self.variables["external_network"]["network_type"] = Prompt.ask(
-            "Network type for access to external network.",
+            "Network type for access to external network",
             default=self.variables["external_network"]["network_type"],
             console=console,
-            choices=['flat', 'vlan'],
+            choices=["flat", "vlan"],
         )
         if self.variables["external_network"]["network_type"] == "vlan":
             self.variables["external_network"]["segmentation_id"] = Prompt.ask(
-                "VLAN ID to use for external network.",
+                "VLAN ID to use for external network",
                 default=self.variables["external_network"]["segmentation_id"],
                 console=console,
             )

--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -280,7 +280,7 @@ class ConfigureCloudStep(BaseStep):
 
 
 @click.command()
-@click.option("-o", "--openrc", description="File to write cloud user credentials to.")
+@click.option("-o", "--openrc", help="Output file for cloud access details.")
 def configure(openrc: str = None) -> None:
     """Configure cloud with some sane defaults."""
     # NOTE: install to user writable location

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -19,6 +19,7 @@ import click
 
 from sunbeam import log
 from sunbeam.commands import bootstrap as bootstrap_cmds
+from sunbeam.commands import configure as configure_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import reset as reset_cmds
 from sunbeam.commands import status as status_cmds
@@ -48,6 +49,7 @@ def main():
     cli.add_command(reset_cmds.reset)
     cli.add_command(status_cmds.status)
     cli.add_command(openrc_cmds.openrc)
+    cli.add_command(configure_cmds.configure)
     cli()
 
 


### PR DESCRIPTION
Add a configure action which prompts the user for a set of data to configure a) a user, project and networking for use of the cloud and b) external network information for the cloud for north/south traffic.

This is applied using a terraform configuration.