### PR TITLE
Add back verbose console output

### DIFF
--- a/sunbeam/log.py
+++ b/sunbeam/log.py
@@ -47,6 +47,12 @@ def setup_root_logging():
             console = True
             break
 
+    # Some logging from the Juju (and dependent) libraries are a bit
+    # noisy. Let's reduce the logging output from these dependencies.
+    # TODO(wolsen) determine if we need to support a -vvv type option
+    for namespace in ["juju", "websockets", "kubernetes.client"]:
+        logging.getLogger(namespace).setLevel(logging.WARNING)
+
     # If the console is enabled, then enable the RichHandler as it will
     # put the log messages to the line and still honor current console
     # entries relevant to the user.

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -33,8 +33,9 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.group("init", context_settings=CONTEXT_SETTINGS)
 @click.option("--quiet", "-q", default=False, is_flag=True)
+@click.option("--verbose", "-v", default=False, is_flag=True)
 @click.pass_context
-def cli(ctx, quiet):
+def cli(ctx, quiet, verbose):
     """Microstack is a small lightweight OpenStack distribution.
 
     To get started with a single node, all-in-one OpenStack installation, start


### PR DESCRIPTION
Add back the -v flag for verbose console output. Previously, the output was just flooded with logging from dependencies. This change restores the -v/--verbose flag and increases the logging level to WARNING for noisy dependencies.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>