### PR TITLE
Update sunbeam charms to xena/beta in bundle

### DIFF
--- a/bundles/etc/bundles/control-plane.yaml
+++ b/bundles/etc/bundles/control-plane.yaml
@@ -14,7 +14,7 @@ applications:
     trust: false
   rabbitmq:
     charm: ch:rabbitmq-k8s
-    channel: edge
+    channel: 3.9/beta
     series: jammy
     scale: 1
     trust: true

--- a/bundles/etc/bundles/control-plane.yaml
+++ b/bundles/etc/bundles/control-plane.yaml
@@ -20,7 +20,7 @@ applications:
     trust: true
   keystone:
     charm: ch:keystone-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
@@ -31,7 +31,7 @@ applications:
       credential-keys: 5M
   glance:
     charm: ch:glance-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
@@ -39,19 +39,19 @@ applications:
       local-repository: 5G
   nova:
     charm: ch:nova-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
   placement:
     charm: ch:placement-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
   neutron:
     charm: ch:neutron-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
@@ -59,7 +59,7 @@ applications:
       os-public-hostname:
   ovn-central:
     charm: ch:ovn-central-k8s
-    channel: 21.09/edge
+    channel: 21.09/beta
     series: jammy
     scale: 1
     trust: true
@@ -69,13 +69,13 @@ applications:
     scale: 1
   horizon:
     charm: ch:horizon-k8s
-    channel: xena/edge
+    channel: xena/beta
     series: jammy
     scale: 1
     trust: true
   ovn-relay:
     charm: ch:ovn-relay-k8s
-    channel: 21.09/edge
+    channel: 21.09/beta
     series: jammy
     scale: 1
     trust: true


### PR DESCRIPTION
Update all sunbeam openstack charms to xena/beta
from xena/edge in the bundle file