### PR TITLE
Add $HOME/.kube read access as plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ apps:
     command: bin/microstack
     plugs:
       - dot-local-share-juju
+      - dot-kube
       - home
       - network
       - network-bind
@@ -95,3 +96,8 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/juju
+
+  dot-kube:
+    interface: personal-files
+    read:
+      - $HOME/.kube


### PR DESCRIPTION
juju needs read access to $HOME/.kube to query
k8s (other than microk8s). Add a plug of interface type personal-files to access $HOME/.kube