### PR TITLE
plugs: Add read only access to kubernetes config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,7 @@ apps:
     command: bin/microstack
     plugs:
       - dot-local-share-juju
+      - dot-kubernetes
       - home
       - network
       - network-bind
@@ -95,3 +96,8 @@ plugs:
     interface: personal-files
     write:
       - $HOME/.local/share/juju
+
+  dot-kubernetes:
+    interface: personal-files
+    read:
+      - $HOME/.kube


### PR DESCRIPTION
Ensure that Juju can read any local .kube/config file found to generate the current set of clouds that can be bootstrapped.