### PR TITLE
Redux of external networking configuration

### DIFF
--- a/configure/etc/configure/main.tf
+++ b/configure/etc/configure/main.tf
@@ -73,6 +73,7 @@ resource "openstack_networking_subnet_v2" "external_subnet" {
     start = var.external_network.start
     end   = var.external_network.end
   }
+  gateway_ip = var.external_network.gateway
 }
 
 # User configuration

--- a/configure/etc/configure/variables.tf
+++ b/configure/etc/configure/variables.tf
@@ -2,6 +2,7 @@
 variable "external_network" {
   type = object({
     cidr             = string
+    gateway          = string
     start            = string
     end              = string
     physical_network = string

--- a/sunbeam/ohv_config/config.py
+++ b/sunbeam/ohv_config/config.py
@@ -16,7 +16,7 @@
 import typing
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress, IPvAnyNetwork
+from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress, IPvAnyInterface
 
 from sunbeam.ohv_config import service
 
@@ -73,8 +73,8 @@ class NetworkConfig(BaseModel):
 
     physnet_name: str = Field(alias="physnet-name", default="physnet1")
     external_bridge: str = Field(alias="external-bridge", default="br-ex")
-    external_network_cidr: Optional[IPvAnyNetwork] = Field(
-        alias="external-network-cidr"
+    external_bridge_address: Optional[IPvAnyInterface] = Field(
+        alias="external-bridge-address"
     )
     dns_domain = Field(alias="dns-domain", default="openstack.local")
     dns_servers: IPvAnyAddress = Field(alias="dns-servers", default="8.8.8.8")


### PR DESCRIPTION
Make the configuration of external networking a little more guided by defaulting to gateway and allocation ranges within the provided CIDR.

Make the last step of the configure action ask whether to enable host local only access to floating IP's - this allows an all-in-one deployment to operate correctly.