### PR TITLE
Only build snap on amd64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,9 @@ version: xena
 confinement: strict
 grade: devel
 
+architectures:
+  - build-on: amd64
+
 layout:
   /usr/share/terraform/plugins:
     symlink: $SNAP_DATA/terraform-plugins


### PR DESCRIPTION
Charms and OCI images are not yet published for arm64 so only target the architecture we actually support right now.