### PR TITLE
Guard against `configure` run before bootstrap

### DIFF
--- a/sunbeam/commands/configure.py
+++ b/sunbeam/commands/configure.py
@@ -390,6 +390,11 @@ def configure(
 
     model = snap.config.get("control-plane.model")
     jhelper = JujuHelper()
+    models = asyncio.get_event_loop().run_until_complete(jhelper.get_models())
+    LOG.debug(f"Juju models: {models}")
+    if model not in models:
+        LOG.error(f"Expected model {model} missing")
+        raise click.ClickException("Please run `microstack bootstrap` first")
     admin_credentials = _retrieve_admin_credentials(jhelper, model)
     ext_network_file = (
         snap.paths.user_common / "etc" / "configure" / "terraform.tfvars.json"


### PR DESCRIPTION
If `configure` is run before `bootstrap` abort configure and tell the user bootstrap is needed. This is mostly likely to be an issue after a `reset` as it may not be clear to the user that a boostrap is needed.