### PR TITLE
Reorder reset steps and update health check

### DIFF
--- a/sunbeam/commands/bootstrap.py
+++ b/sunbeam/commands/bootstrap.py
@@ -68,7 +68,12 @@ def bootstrap() -> None:
         preflight_checks.extend([JujuSnapCheck(), Microk8sSnapCheck()])
     if node_role.is_compute_node():
         preflight_checks.extend(
-            [OpenStackHypervisorSnapCheck(), OpenStackHypervisorSnapHealth()]
+            [
+                OpenStackHypervisorSnapCheck(),
+                # Just check config service is responding as hypervisor will report
+                # that it is not ready until it has recieved required config.
+                OpenStackHypervisorSnapHealth(check_health_report=False),
+            ]
         )
 
     for check in preflight_checks:

--- a/sunbeam/commands/reset.py
+++ b/sunbeam/commands/reset.py
@@ -69,6 +69,10 @@ def reset() -> None:
 
     plan = []
 
+    if node_role.is_compute_node() or node_role.is_converged_node():
+        LOG.debug("Append steps to reset the compute node")
+        plan.append(ohv.ResetConfigStep())
+
     if node_role.is_control_node() or node_role.is_converged_node():
         LOG.debug("Append steps to reset the control node")
         # FIXME: This needs to be done only in non HA
@@ -76,10 +80,6 @@ def reset() -> None:
         # exists and getting used for other purposes
         plan.append(juju.DestroyModelStep(jhelper=jhelper, model=model))
         plan.append(PurgeTerraformStateStep())
-
-    if node_role.is_compute_node() or node_role.is_converged_node():
-        LOG.debug("Append steps to reset the compute node")
-        plan.append(ohv.ResetConfigStep())
 
     for step in plan:
         LOG.debug(f"Starting step {step.name}")

--- a/sunbeam/jobs/checks.py
+++ b/sunbeam/jobs/checks.py
@@ -118,11 +118,12 @@ class OpenStackHypervisorSnapCheck(Check):
 class OpenStackHypervisorSnapHealth(Check):
     """Check if openStack-hypervisor snap is healthy."""
 
-    def __init__(self):
+    def __init__(self, check_health_report=True):
         super().__init__(
             "Check health of openstack-hypervisor snap",
             "Checking health of openstack-hypervisor",
         )
+        self.check_health_report = check_health_report
 
     def run(self) -> bool:
         """Check for openstack-hypervisor content."""
@@ -136,7 +137,7 @@ class OpenStackHypervisorSnapHealth(Check):
         ):
             self.message = "Failed to communitcate with openstack-hypervisor"
             return False
-        if not hypervisor_health.get("ready"):
+        if self.check_health_report and not hypervisor_health.get("ready"):
             self.message = "openstack-hypervisor reporting not ready"
             return False
 


### PR DESCRIPTION
* When reset is called trigger a reset of the openstack-hypervisor snap first allowing it to shutdown services gracefully before tearing down the model.
* When checking health of hypervisor just check that the health check responds correctly. If this is an initial bootstrap then the hypervisor will report that it is not ready as it is missing prerequisite config to start services.