### PR TITLE
Refresh for tls-certificates v1 changes

### DIFF
--- a/sunbeam/commands/ohv.py
+++ b/sunbeam/commands/ohv.py
@@ -281,9 +281,9 @@ class UpdateNetworkConfigStep(OHVBaseStep):
             self.config.ovn_sb_connection = url
             skip = False
 
-        app = "vault"
-        action_cmd = "generate-certificate"
-        action_params = {"cn": cn, "sans": sans, "type": "client"}
+        app = "certificate-authority"
+        action_cmd = "generate-self-signed-certificate"
+        action_params = {"common-name": cn, "sans": sans}
         action_result = asyncio.get_event_loop().run_until_complete(
             self.jhelper.run_action(self.model, app, action_cmd, action_params)
         )


### PR DESCRIPTION
The refresh to v1 of the tls-certificates interfaces switches terraform to deploy the tls-certificates-operator rather than the icey-vault-k8s charm.

Update bootstrap code to use the 'certificate-authority' application when generating TLS information for hypervisor communication to OVN.