### PR TITLE
Set upper bound for juju

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ pbr>2.1.0 # Apache 2.0
 git+https://github.com/albertodonato/snap-helpers#egg=snap-helpers # LGPLv3
 click>=8.1.3 # BSD
 rich # MIT
-#juju # Apache 2
-git+https://github.com/juju/python-libjuju#egg=juju
+
+# Set upper bound to match Juju 3.1.x series target
+juju<3.2 # Apache 2
 
 # Used for communication with snapd socket
 requests # Apache 2


### PR DESCRIPTION
Ensure that python-libjuju versions that match the Juju 3.1.x series target for compatibility are used as part of the snap code.

This aligns with the shift in matching version compatibility in python-libjuju.