### PR TITLE
Implement the launch command for launching an instance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@ rich # MIT
 # Set upper bound to match Juju 3.1.x series target
 juju<3.2 # Apache 2
 
+# Used in the launch command to launch an instance
+openstacksdk==0.61.*
+petname
+
 # Used for communication with snapd socket
 requests # Apache 2
 requests-unixsocket # Apache 2

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -79,11 +79,6 @@ def launch(
     """
     Launch an OpenStack instance
     """
-    LOG.debug(f"The supplied key name is {key}.")
-    model = snap.config.get("control-plane.model")
-    jhelper = juju.JujuHelper()
-    server_id = ""
-    keypath = ""
     console.print("Launching an OpenStack instance ... ")
     try:
         conn = openstack.connect(

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -17,11 +17,12 @@ import logging
 import os
 import subprocess
 
+from typing import List
+
 import click
 import openstack
 import petname
 
-from typing import List
 
 from rich.console import Console
 from snaphelpers import Snap
@@ -60,14 +61,14 @@ def check_keypair(openstack_conn: openstack.connection.Connection):
     home = os.environ.get("SNAP_REAL_HOME")
     key_path = f"{home}/sunbeam"
     try:
-        keypair = openstack_conn.compute.get_keypair("sunbeam")
+        openstack_conn.compute.get_keypair("sunbeam")
         console.print("Found sunbeam key!")
     except openstack.exceptions.ResourceNotFound:
         console.print(
             f"No sunbeam key found. Creating SSH key at {key_path}/sunbeam"
         )
         id_ = openstack_conn.compute.create_keypair(name="sunbeam")
-        with open(key_path, 'w') as file_:
+        with open(key_path, 'w', encoding="utf-8") as file_:
             file_.write(id_.private_key)
             check('chmod', '600', key_path)
     return key_path
@@ -93,12 +94,10 @@ def launch(
         )
     except Exception:
         console.print(
-            (
-                f"Unable to connect to OpenStack.",
-                f" Is OpenStack running?",
-                f" Have you run the configure command?",
-                f" Do you have a clouds.yaml file?"
-            )
+                "Unable to connect to OpenStack.",
+                " Is OpenStack running?",
+                " Have you run the configure command?",
+                " Do you have a clouds.yaml file?"
         )
         return
 
@@ -134,15 +133,15 @@ def launch(
 
     with console.status("Allocating IP address to instance ... "):
         external_network = conn.network.find_network("external-network")
-        ip = conn.network.create_ip(floating_network_id=external_network.id)
+        ip_ = conn.network.create_ip(floating_network_id=external_network.id)
         conn.compute.add_floating_ip_to_server(
             server_id,
-            ip.floating_ip_address
+            ip_.floating_ip_address
         )
 
     console.print(
         (
-            f"Access instance with",
-            f"`ssh -i {key_path} ubuntu@{ip.floating_ip_address}"
+            "Access instance with",
+            f"`ssh -i {key_path} ubuntu@{ip_.floating_ip_address}"
         )
     )

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -98,7 +98,8 @@ def launch(
             # some placeholder text for the message at the end of this
             # routine, but don't worry about verifying it. We trust the
             # caller to have created it!
-            key_path = '/path/to/ssh/key'
+            home = os.environ.get("SNAP_REAL_HOME")
+            key_path = f"{home}/.ssh/{key}"
 
     with console.status("Creating the OpenStack instance ... "):
         instance_name = petname.Generate()

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -137,4 +137,4 @@ key_name = %s
         ip = conn.network.create_ip(floating_network_id=external_network.id)
         conn.compute.add_floating_ip_to_server(server_id, ip.floating_ip_address)
 
-    console.print("Access the instance with `ssh -i {key_path} ubuntu@{ip.floating_ip_address}")
+    console.print(f"Access the instance with `ssh -i {key_path} ubuntu@{ip.floating_ip_address}")

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -92,35 +92,9 @@ def launch(
     server_id = ""
     keypath = ""
     console.print("Launching an OpenStack instance ... ")
-    with console.status("Getting Keystone admin information ... "):
-        app = "keystone"
-        action_cmd = "get-admin-account"
-        action_result = asyncio.get_event_loop().run_until_complete(
-            jhelper.run_action(model, app, action_cmd)
-        )
-
-        if action_result.get("return-code", 0) > 1:
-            _message = "Unable to retrieve OpenStack credentials from Keystone service"
-            raise click.ClickException(_message)
-        else:
-            LOG.debug("Successfully retrieved admin info from Keystone")
-            
-        os_username = action_result.get("username")
-        os_password = action_result.get("password")
-        os_auth_url = action_result.get("public-endpoint")
-        os_user_domain_name = action_result.get("user-domain-name")
-        os_project_domain_name = action_result.get("project-domain-name")
-        os_project_name = action_result.get("project-name")
-        os_auth_version = action_result.get("api-version")
-        os_identity_api_version = action_result.get("api_version")
-
+    
     conn = openstack.connect(
-        os_auth_url=os_auth_url,
-        project_name=os_project_name,
-        username=os_username,
-        password=os_password,
-        user_domain_name=os_user_domain_name,
-        project_domain_name=os_project_domain_name,
+        cloud="sunbeam"
     )
 
     with console.status("Checking for SSH key pair ... "):

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -92,7 +92,7 @@ def launch(
         conn = openstack.connect(
             cloud="sunbeam"
         )
-    except Exception:
+    except openstack.exceptions.SDKException:
         console.print(
                 "Unable to connect to OpenStack.",
                 " Is OpenStack running?",

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 import os
 import subprocess
@@ -26,8 +25,6 @@ from typing import List
 
 from rich.console import Console
 from snaphelpers import Snap
-
-from sunbeam.commands import juju
 
 LOG = logging.getLogger(__name__)
 console = Console()

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -71,7 +71,6 @@ def check_keypair(openstack_conn: openstack.connection.Connection):
     check('chmod', '700', key_dir)
 
     id_ = openstack_conn.compute.create_keypair(name="sunbeam")
-
     with open(key_path, 'w') as file_:
         file_.write(id_.private_key)
         check('chmod', '600', key_path)
@@ -92,10 +91,13 @@ def launch(
     server_id = ""
     keypath = ""
     console.print("Launching an OpenStack instance ... ")
-    
-    conn = openstack.connect(
-        cloud="sunbeam"
-    )
+    try:
+        conn = openstack.connect(
+            cloud="sunbeam"
+        )
+    except:
+        console.print(f"Unable to connect to OpenStack. Is OpenStack running? Have you run the configure command? Do you have a clouds.yaml file?")
+        return
 
     with console.status("Checking for SSH key pair ... "):
         if key == "sunbeam":

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -140,8 +140,6 @@ def launch(
         )
 
     console.print(
-        (
             "Access instance with",
             f"`ssh -i {key_path} ubuntu@{ip_.floating_ip_address}"
-        )
     )

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import os
+import subprocess
+
+import click
+import openstack
+import petname
+
+from typing import List
+
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands import juju
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+def check_output(*args: List[str]) -> str:
+    """Execute a shell command, returning the output of the command.
+
+    :param args: strings to be composed into the bash call.
+
+    Include our env; pass in any extra keyword args.
+    """
+    return subprocess.check_output(args, universal_newlines=True,
+                                   env=os.environ).strip()
+
+def check(*args: List[str]) -> int:
+    """Execute a shell command, raising an error on failed excution.
+
+    :param args: strings to be composed into the bash call.
+
+    """
+    return subprocess.check_call(args, env=os.environ)
+
+def check_keypair(openstack_conn: openstack.connection.Connection):
+    """
+    Check for the sunbeam keypair's existence, creating it if it doesn't.
+
+    """
+    key_path = f"~/.ssh/sunbeam"
+    LOG.debug(f"check_keypair Key Path is: {key_path}")
+    if os.path.exists(key_path):
+        return key_path
+    console.print('Creating local "sunbeam" ssh key at {}'.format(key_path))
+    # TODO: make sure that we get rid of this path on snap
+    # uninstall. If we don't, check to make sure that Sunbeam
+    # has a sunbeam ssh key, in addition to checking for the
+    # existence of the file.
+    key_dir = os.sep.join(key_path.split(os.sep)[:-1])
+    check('mkdir', '-p', key_dir)
+    check('chmod', '700', key_dir)
+
+    id_ = openstack_conn.compute.create_keypair(name="sunbeam")
+
+    with open(key_path, 'w') as file_:
+        file_.write(id_.private_key)
+        check('chmod', '600', key_path)
+
+    return key_path
+
+@click.command()
+@click.option("-k", "--key", default="sunbeam", help="The SSH key to use for the instance")
+def launch(
+    key: str = "sunbeam"
+) -> None:
+    """
+    Launch an OpenStack instance
+    """
+    LOG.debug(f"The supplied key name is {key}.")
+    model = snap.config.get("control-plane.model")
+    jhelper = juju.JujuHelper()
+    server_id = ""
+    keypath = ""
+    console.print("Launching an OpenStack instance ... ")
+    with console.status("Getting Keystone admin information ... "):
+        app = "keystone"
+        action_cmd = "get-admin-account"
+        action_result = asyncio.get_event_loop().run_until_complete(
+            jhelper.run_action(model, app, action_cmd)
+        )
+
+        if action_result.get("return-code", 0) > 1:
+            _message = "Unable to retrieve OpenStack credentials from Keystone service"
+            raise click.ClickException(_message)
+        else:
+            LOG.debug("Successfully retrieved admin info from Keystone")
+            
+        os_username = action_result.get("username")
+        os_password = action_result.get("password")
+        os_auth_url = action_result.get("public-endpoint")
+        os_user_domain_name = action_result.get("user-domain-name")
+        os_project_domain_name = action_result.get("project-domain-name")
+        os_project_name = action_result.get("project-name")
+        os_auth_version = action_result.get("api-version")
+        os_identity_api_version = action_result.get("api_version")
+
+    conn = openstack.connect(
+        os_auth_url=os_auth_url,
+        project_name=os_project_name,
+        username=os_username,
+        password=os_password,
+        user_domain_name=os_user_domain_name,
+        project_domain_name=os_project_domain_name,
+    )
+
+    with console.status("Checking for SSH key pair ... "):
+        if key == "sunbeam":
+            # Make sure that we have a default ssh key to hand off to the
+            # instance.
+            key_path = check_keypair(conn)
+        else:
+            # We've been passed an ssh key with an unknown path. Drop in
+            # some placeholder text for the message at the end of this
+            # routine, but don't worry about verifying it. We trust the
+            # caller to have created it!
+            key_path = '/path/to/ssh/key'
+
+    with console.status("Creating the OpenStack instance ... "):
+        instance_name = petname.Generate()
+        image = conn.compute.find_image("ubuntu-jammy")
+        flavor = conn.compute.find_flavor("m1.tiny")
+        network = conn.network.find_network("demo-network")
+        keypair = conn.compute.find_keypair(key)
+        LOG.debug(
+            """
+Creating an instance with this configuration:
+name     = %s,
+image    = %s,
+flavor   = %s,
+network  = %s,
+key_name = %s
+            """ % (instance_name, image.id, flavor.id, network.id, keypair.name)
+            )
+        server = conn.compute.create_server(
+            name=instance_name,
+            image_id=image.id,
+            flavor_id=flavor.id,
+            networks=[{"uuid": network.id}],
+            key_name=keypair.name
+        )
+
+        server = conn.compute.wait_for_server(server)
+        server_id = server.id
+
+    with console.status("Allocating IP address to instance ... "):
+        external_network = conn.network.find_network("external-network")
+        ip = conn.network.create_ip(floating_network_id=external_network.id)
+        conn.compute.add_floating_ip_to_server(server_id, ip.floating_ip_address)
+
+    console.print("Access the instance with `ssh -i {key_path} ubuntu@{ip.floating_ip_address}")

--- a/sunbeam/commands/launch.py
+++ b/sunbeam/commands/launch.py
@@ -111,8 +111,7 @@ def launch(
             # some placeholder text for the message at the end of this
             # routine, but don't worry about verifying it. We trust the
             # caller to have created it!
-            home = os.environ.get("SNAP_REAL_HOME")
-            key_path = f"{home}/.ssh/{key}"
+            key_path = "/path/to/your/key"
 
     with console.status("Creating the OpenStack instance ... "):
         instance_name = petname.Generate()

--- a/sunbeam/main.py
+++ b/sunbeam/main.py
@@ -22,6 +22,7 @@ from sunbeam.commands import bootstrap as bootstrap_cmds
 from sunbeam.commands import configure as configure_cmds
 from sunbeam.commands import inspect as inspect_cmds
 from sunbeam.commands import install_script as install_script_cmds
+from sunbeam.commands import launch as launch_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import reset as reset_cmds
 from sunbeam.commands import status as status_cmds
@@ -55,6 +56,7 @@ def main():
     cli.add_command(configure_cmds.configure)
     cli.add_command(inspect_cmds.inspect)
     cli.add_command(install_script_cmds.install_script)
+    cli.add_command(launch_cmds.launch)
     cli()
 
 


### PR DESCRIPTION
This PR implements MicroStack's previous `launch` command, which would launch an OpenStack instance with a single command.

This implementation uses the OpenStack SDK instead of relying on the OpenStack CLI snap. The `launch` command will deploy an instance using the disk image, flavors, and network, and other assets setup using the `microstack configure` command. The `configure` command must run first before the `launch` command will run.

This PR also adds output for the `clouds.yaml` file to the `configure` command. The `launch` command requires the `clouds.yaml` file to be present in order to function.

Please let me know how the implementation can be better! I'm happy to make changes as needed for this feature to get landed.